### PR TITLE
Checks now for unexpected stream shutdowns and tries to restart camera stream to avoid freezing

### DIFF
--- a/WebcamOnDesktop/Views/CameraPage.xaml.cs
+++ b/WebcamOnDesktop/Views/CameraPage.xaml.cs
@@ -1,26 +1,16 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Controls.Primitives;
-using Windows.UI.Xaml.Data;
-using Windows.UI.Xaml.Input;
-using Windows.UI.Xaml.Media;
-using Windows.UI.Xaml.Navigation;
 using System.Runtime.CompilerServices;
-using Windows.UI.ViewManagement;
+using System.Threading.Tasks;
+using WebcamOnDesktop.Helpers;
+using WebcamOnDesktop.Services;
 using Windows.ApplicationModel.Core;
 using Windows.UI.Core;
-using WebcamOnDesktop.Helpers;
-using System.Threading.Tasks;
-using WebcamOnDesktop.Services;
+using Windows.UI.ViewManagement;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media.Animation;
+using Windows.UI.Xaml.Navigation;
 
 
 // Die Elementvorlage "Leere Seite" wird unter https://go.microsoft.com/fwlink/?LinkId=234238 dokumentiert.
@@ -47,12 +37,12 @@ namespace WebcamOnDesktop.Views
                 await Windows.Storage.ApplicationData.Current.LocalSettings.SaveAsync("FlipHorizontal", "True"); 
             }
             */
-            
-            cameraControl.FlipHorizontal = await Windows.Storage.ApplicationData.Current.LocalSettings.ReadAsync<bool>("FlipHorizontal");    
+
+            cameraControl.FlipHorizontal = await Windows.Storage.ApplicationData.Current.LocalSettings.ReadAsync<bool>("FlipHorizontal");
             cameraControl.FlipVertical = await Windows.Storage.ApplicationData.Current.LocalSettings.ReadAsync<bool>("FlipVertical");
 
             await cameraControl.InitializeCameraAsync();
-           
+
             if (ApplicationView.GetForCurrentView().IsViewModeSupported(ApplicationViewMode.CompactOverlay))
             {
                 //bool modeSwitched = await ApplicationView.GetForCurrentView().TryEnterViewModeAsync(ApplicationViewMode.CompactOverlay);
@@ -69,14 +59,14 @@ namespace WebcamOnDesktop.Views
                 CoreApplication.GetCurrentView().TitleBar.ExtendViewIntoTitleBar = true;
                 //make whole window dragable
                 Window.Current.SetTitleBar(ContentArea);
-                
+
             }
             Window.Current.Activated += Current_Activated;
-            
+
 
         }
 
-       
+
 
         private async void Current_Activated(object sender, Windows.UI.Core.WindowActivatedEventArgs e)
         {
@@ -129,6 +119,6 @@ namespace WebcamOnDesktop.Views
 
         }
 
-    
+
     }
 }

--- a/WebcamOnDesktop/Views/MainPage.xaml.cs
+++ b/WebcamOnDesktop/Views/MainPage.xaml.cs
@@ -1,18 +1,13 @@
 ﻿using System.ComponentModel;
-using Windows.UI.Xaml.Controls;
 using System.Runtime.CompilerServices;
-
-using System.Threading.Tasks;
-using System.Collections.ObjectModel;
-using System.Collections.Generic;
-using System.Linq;
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Navigation;
 using WebcamOnDesktop.Controls;
-using Windows.UI.ViewManagement;
-using Windows.Foundation;
 using WebcamOnDesktop.Services;
+using Windows.Foundation;
+using Windows.UI.ViewManagement;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media.Animation;
+using Windows.UI.Xaml.Navigation;
 
 // Die Elementvorlage "Leere Seite" wird unter https://go.microsoft.com/fwlink/?LinkId=402352&clcid=0x407 dokumentiert.
 
@@ -23,7 +18,7 @@ namespace WebcamOnDesktop.Views
     /// </summary>
     public sealed partial class MainPage : Page, INotifyPropertyChanged
     {
-        ObservableCollection<Camera> cameras = new ObservableCollection<Camera>();
+        //ObservableCollection<Camera> cameras = new ObservableCollection<Camera>();
         public MainPage()
         {
             InitializeComponent();
@@ -41,9 +36,9 @@ namespace WebcamOnDesktop.Views
             // Set focus so the first item of the listview has focus
             // instead of some item which is not visible on page load
             CameraListView.Focus(FocusState.Programmatic);
-  
+
         }
-        
+
 
 
         private void CompactOverlayButton_Click(object sender, RoutedEventArgs e)
@@ -62,7 +57,7 @@ namespace WebcamOnDesktop.Views
             //save name of camera (this is used by target page CameraPage, note: is it dirty to use localSettings as alternative to a mvvm pattern?
             string cameraSelected = (string)localSettings?.Values["cameraSelected"];
             int cameraSelectedIndex = 0;
-            for (int i=0; i<CameraListView.Items.Count; i++)
+            for (int i = 0; i < CameraListView.Items.Count; i++)
             {
                 if (CameraListView.Items[i].ToString() == cameraSelected)
                 {
@@ -70,9 +65,9 @@ namespace WebcamOnDesktop.Views
                     break;
                 }
             }
-            
+
             CameraListView.SelectedIndex = cameraSelectedIndex;
-            
+
         }
 
         protected override void OnNavigatedFrom(NavigationEventArgs e)
@@ -80,8 +75,8 @@ namespace WebcamOnDesktop.Views
             base.OnNavigatedFrom(e);
             Windows.Storage.ApplicationDataContainer localSettings = Windows.Storage.ApplicationData.Current.LocalSettings;
             //preselect camera if it was previously selected
-            localSettings.Values["cameraSelected"] =  CameraListView.SelectedItem?.ToString();
-            
+            localSettings.Values["cameraSelected"] = CameraListView.SelectedItem?.ToString();
+
         }
 
         public event PropertyChangedEventHandler PropertyChanged;

--- a/WebcamOnDesktop/Views/ShellPage.xaml.cs
+++ b/WebcamOnDesktop/Views/ShellPage.xaml.cs
@@ -12,7 +12,6 @@ using Windows.System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
-using Windows.UI.Xaml.Media.Animation;
 using Windows.UI.Xaml.Navigation;
 
 using WinUI = Microsoft.UI.Xaml.Controls;
@@ -93,7 +92,7 @@ namespace WebcamOnDesktop.Views
                 Selected = selectedItem;
             }
         }
-        
+
 
         private WinUI.NavigationViewItem GetSelectedItem(IEnumerable<object> menuItems, Type pageType)
         {
@@ -158,7 +157,7 @@ namespace WebcamOnDesktop.Views
 
         public event PropertyChangedEventHandler PropertyChanged;
 
-        private void Set<T>(ref T storage, T value, [CallerMemberName]string propertyName = null)
+        private void Set<T>(ref T storage, T value, [CallerMemberName] string propertyName = null)
         {
             if (Equals(storage, value))
             {

--- a/WebcamOnDesktop/WebcamOnDesktop.csproj
+++ b/WebcamOnDesktop/WebcamOnDesktop.csproj
@@ -275,7 +275,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.13</Version>
+      <Version>6.2.14</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
       <Version>2.5.0</Version>
@@ -284,7 +284,7 @@
       <Version>2.0.1</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>13.0.1</Version>
+      <Version>13.0.3</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Freezing happens e.g. because of switching through virtual windows desktops, see #23 